### PR TITLE
Gal 23 (Pack filters)

### DIFF
--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
@@ -118,3 +118,9 @@
     transition: transform 0.3s ease, box-shadow 0.3s ease; 
     cursor: pointer;
 }
+
+.filter {
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+}

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
@@ -120,7 +120,43 @@
 }
 
 .filter {
+    justify-content: space-around;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    padding-top: 20px;
+    padding-bottom: 20px;
+
+    background-color: #ccc6c0;
+    margin-bottom: 16px;
+}
+.filter-column {
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    padding: 5px;
+    justify-content: space-around;
+    
+    o-button {
+        color: #4e4c4a;
+    }
 }
+
+.filter-element {
+    margin-bottom: 10px;
+}
+
+.details {
+    summary:hover {
+        width: max-content;
+        cursor: pointer;
+    }
+}
+
+.filter-button {
+    margin-top: 10px;
+}
+
+.full-page {
+    height: 77vh;
+}
+

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.css
@@ -158,5 +158,12 @@
 
 .full-page {
     height: 77vh;
+    .o-data-toolbar {
+        align-items: start;
+        .title {
+            font-size: 25px;
+            margin-bottom: 10px;
+        }
+    }
 }
 

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
@@ -1,3 +1,43 @@
+<!-- Boton para abrir dialogo -->
+<o-button attr="packFilter" type="FAB" icon="tune" layout-padding (click)="showFilter($event)"></o-button>
+
+<!-- Plantilla para el dialogo -->
+<ng-template #filterDialogTemplate>
+  <o-form editable-detail="no" show-header="no">
+    <div class="filter">
+      <!-- Filtro de palabras clave -->
+      <o-text-input attr="pck_name" read-only="no" placeholder="Nombre"></o-text-input>
+      
+      <!-- Filtro de rango de fechas -->
+      <o-date-input attr="pck_date_begin" read-only="no" label="Fecha inicio" format="DD/MM/YYYY HH:MM:SS"></o-date-input>
+      <o-date-input attr="pck_date_end" read-only="no" label="Fecha fin"></o-date-input>
+      
+      <!-- Filtro de número de días -->
+      <o-integer-input attr="pck_days" read-only="no" label="Número de días"></o-integer-input>
+      
+      <!-- Filtro de rango de precio -->
+      <o-real-input attr="pck_price_min" read-only="false" placeholder="Precio mínimo"></o-real-input>
+      <o-real-input attr="pck_price_max" read-only="false" placeholder="Precio máximo"></o-real-input>
+      
+      <!-- Filtro de número de viajeros -->
+      <o-integer-input attr="pck_participants" read-only="no" label="Número de viajeros"></o-integer-input>
+      
+      <!-- Filtro de lugar -->
+      <o-combo attr="gui_c_name" searchable="yes" read-only="no" service="places" entity="place" keys="PLACE_ID"
+        columns="PLACE_ID;PLACE_NAME" visible-columns="PLACE_NAME" value-column="PLACE_ID"></o-combo>
+    </div>
+
+    <o-filter-builder #filterBuilder attr="packFilter"
+      filters="pck_name:pck_name;pck_date_begin:pck_date_begin;pck_date_end:pck_date_end;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
+      [target]="packGrid" query-on-change="yes" query-on-change-delay="500" [expression-builder]="filter">
+    </o-filter-builder>
+
+    <div class="dialog-buttons" fxLayout="row" fxLayoutAlign="end center">
+      <button mat-button (click)="applyFilter()">Filter</button>
+      <button mat-button (click)="closeDialog()">Close</button>
+    </div>
+  </o-form>
+</ng-template>
 <o-grid #packGrid attr="packGrid" title="PACKS" service="packs" entity="allPacks" keys="P.pck_id"
     columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;pcs_id;img_code;pck_days;creation_date"
     query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="creation_date:desc"

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
@@ -1,49 +1,63 @@
-<o-form class="form" editable-detail="yes" show-header="no">
-  <div class="filter">
-    <o-text-input attr="pck_name" read-only="no" fxFlex="100" label="Nombre" appearance="outline"></o-text-input>
-    <o-integer-input attr="pck_days" label="Number of Days" appearance="outline"></o-integer-input>
-    <o-real-input attr="pck_price_min" label="Min Price" appearance="outline"></o-real-input>
-    <o-real-input attr="pck_price_max" label="Max Price" appearance="outline"></o-real-input>
-    <o-integer-input attr="pck_participants" label="Number of Travelers" appearance="outline"></o-integer-input>
-    <o-combo #comboCity attr="gui_c_name" label="Ciudad"  translate="yes"
-      query-method="query" sort="ASC" value-column="gui_c_name" required="no" service="guideCities" multiple="no" null-selection="yes" entity="guideCities"
-      columns="gui_c_name" visible-columns="gui_c_name" keys="gui_c_id"></o-combo>
-  </div>
-  <o-filter-builder #filterBuilder attr="thefilter"
-    filters="pck_name:pck_name;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
-    [target]="packGrid" query-on-change="yes" query-on-change-delay="500" [expression-builder]="createFilter"></o-filter-builder>
-</o-form>
+<div class="full-page">
+  <o-form #filterForm class="form" editable-detail="yes" show-header="no">
 
-<o-grid #packGrid attr="packGrid" title="PACKS" service="packs" entity="allPacks" keys="P.pck_id"
-    columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;img_code;pck_days;creation_date"
-    query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="creation_date:desc"
-    sortable-columns="" 
-    quick-filter-columns="pck_name;pck_price;pck_participants;gui_c_name" filter-case-sensitive="yes"
-    insert-button="true" refresh-button="false" pageable="yes"
-    pagination-controls="true" gutter-size="4px" fixed-header="yes" grid-item-height="320px" detail-mode="none"
-    insert-button-floatable="no">
-    <o-grid-item *ngFor="let data of packGrid.dataArray">
-        <div (click)="openDetail(data)" fxLayout="column" fxLayoutAlign="space-between stretch" class="mat-elevation-z1 packCard">
-            <div class="cardHeader">
-                <span class="pack-name">{{truncateName(data.pck_name)}}</span>
-            </div>
-            <div class="cardContent">
-                <div class="cardImg">
-                    <img class="preview-image" [src]="getImageSrc(data.img_code)">
-                </div>
-                <div class="cardInfo">
-                    <ul style="list-style-type: none;" class="list">
-                        <li *ngIf="!data.pck_participants"><mat-icon class="icon">groups</mat-icon>{{'-'}}</li>
-                        <li *ngIf="data.pck_participants && data.pck_participants == 1"><mat-icon class="icon">groups</mat-icon>{{data.pck_participants}} {{'PERSON' | oTranslate}}</li>
-                        <li *ngIf="data.pck_participants && data.pck_participants > 1"><mat-icon class="icon">groups</mat-icon>{{data.pck_participants}} {{'PEOPLE' | oTranslate}}</li>
-                        <li *ngIf="!data.pck_days"><mat-icon class="icon">timer</mat-icon>-</li>
-                        <li *ngIf="data.pck_days && data.pck_days == 1"><mat-icon class="icon">timer</mat-icon>{{data.pck_days}} {{'DAY' | oTranslate}}</li>
-                        <li *ngIf="data.pck_days && data.pck_days > 1"><mat-icon class="icon">timer</mat-icon>{{data.pck_days}} {{'DAYS' | oTranslate}}</li>
-                        <li><mat-icon class="icon">pin_drop</mat-icon>{{truncateInfo(data.gui_c_name)}}</li>
-                        <li><mat-icon class="icon">payments</mat-icon>{{data.pck_price}} €</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </o-grid-item>
-</o-grid>
+    <div class="filter">
+      <div class="filter-column">
+        <o-text-input class="filter-element" attr="pck_name" read-only="no" fxFlex="100" label="Nombre" ></o-text-input>
+        <o-integer-input  attr="pck_days" label="Number of Days" min="0"></o-integer-input>
+      </div>
+      <div class="filter-column">
+        <o-integer-input class="filter-element" attr="pck_price_min" label="Min Price" min="0"></o-integer-input>
+        <o-integer-input  attr="pck_price_max" label="Max Price" min="0"></o-integer-input>
+      </div>
+      <div class="filter-column">
+        <o-integer-input class="filter-element" attr="pck_participants" min="0" label="Number of Travelers" ></o-integer-input>
+        <o-combo  #comboCity attr="gui_c_name" label="Ciudad"  translate="yes"
+          query-method="query" sort="ASC" value-column="gui_c_name" required="no" service="guideCities" multiple="no" null-selection="yes" entity="guideCities"
+          columns="gui_c_name" visible-columns="gui_c_name" keys="gui_c_id"></o-combo>
+      </div>
+      <div class="filter-column">
+        <o-button attr="filter" [oFilterBuilderQuery]="filterBuilder" type="ICON" icon="search" matTooltip="Search" class="filter-button"></o-button>
+        <o-button attr="clear" type="ICON" icon="delete" matTooltip="Clear filters" class="filter-button" [oFilterBuilderClear]="filterBuilder"  [oFilterBuilderQuery]="filterBuilder" ></o-button>
+      </div>
+    </div>
+    
+    <o-filter-builder #filterBuilder attr="thefilter"
+      filters="pck_name:pck_name;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
+      [target]="packGrid" query-on-change="no" query-on-change-delay="500" [expression-builder]="createFilter"></o-filter-builder>
+  </o-form>
+  
+  <o-grid #packGrid attr="packGrid" title="PACKS" service="packs" entity="allPacks" keys="P.pck_id"
+      columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;img_code;pck_days;creation_date"
+      query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="creation_date:desc"
+      sortable-columns=""
+      quick-filter-columns="pck_name;pck_price;pck_participants;gui_c_name" filter-case-sensitive="yes"
+      insert-button="true" refresh-button="false" pageable="yes"
+      pagination-controls="true" gutter-size="4px" fixed-header="yes" grid-item-height="320px" detail-mode="none"
+      insert-button-floatable="no">
+      <o-grid-item *ngFor="let data of packGrid.dataArray">
+          <div (click)="openDetail(data)" fxLayout="column" fxLayoutAlign="space-between stretch" class="mat-elevation-z1 packCard">
+              <div class="cardHeader">
+                  <span class="pack-name">{{truncateName(data.pck_name)}}</span>
+              </div>
+              <div class="cardContent">
+                  <div class="cardImg">
+                      <img class="preview-image" [src]="getImageSrc(data.img_code)">
+                  </div>
+                  <div class="cardInfo">
+                      <ul style="list-style-type: none;" class="list">
+                          <li *ngIf="!data.pck_participants"><mat-icon class="icon">groups</mat-icon>{{'-'}}</li>
+                          <li *ngIf="data.pck_participants && data.pck_participants == 1"><mat-icon class="icon">groups</mat-icon>{{data.pck_participants}} {{'PERSON' | oTranslate}}</li>
+                          <li *ngIf="data.pck_participants && data.pck_participants > 1"><mat-icon class="icon">groups</mat-icon>{{data.pck_participants}} {{'PEOPLE' | oTranslate}}</li>
+                          <li *ngIf="!data.pck_days"><mat-icon class="icon">timer</mat-icon>-</li>
+                          <li *ngIf="data.pck_days && data.pck_days == 1"><mat-icon class="icon">timer</mat-icon>{{data.pck_days}} {{'DAY' | oTranslate}}</li>
+                          <li *ngIf="data.pck_days && data.pck_days > 1"><mat-icon class="icon">timer</mat-icon>{{data.pck_days}} {{'DAYS' | oTranslate}}</li>
+                          <li><mat-icon class="icon">pin_drop</mat-icon>{{truncateInfo(data.gui_c_name)}}</li>
+                          <li><mat-icon class="icon">payments</mat-icon>{{data.pck_price}} €</li>
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </o-grid-item>
+  </o-grid>
+</div>

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
@@ -28,12 +28,11 @@
   </o-form>
   
   <o-grid #packGrid attr="packGrid" title="PACKS" service="packs" entity="allPacks" keys="P.pck_id"
-      columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;img_code;pck_days;creation_date"
-      query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="creation_date:desc"
-      sortable-columns=""
-      quick-filter-columns="pck_name;pck_price;pck_participants;gui_c_name" filter-case-sensitive="yes"
-      insert-button="true" refresh-button="false" pageable="yes"
-      pagination-controls="true" gutter-size="4px" fixed-header="yes" grid-item-height="320px" detail-mode="none"
+      columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;img_code;pck_days;P.creation_date"
+      query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="P.creation_date:desc"
+      sortable-columns="" quick-filter="false"  filter-case-sensitive="yes"
+      insert-button="true" refresh-button="false" pageable="yes" filter 
+      pagination-controls="true" gutter-size="4px" fixed-header="yes" grid-item-height="280px" detail-mode="none"
       insert-button-floatable="no">
       <o-grid-item *ngFor="let data of packGrid.dataArray">
           <div (click)="openDetail(data)" fxLayout="column" fxLayoutAlign="space-between stretch" class="mat-elevation-z1 packCard">

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
@@ -2,26 +2,31 @@
   <o-form #filterForm class="form" editable-detail="yes" show-header="no">
 
     <div class="filter">
+      <!-- Name and number of days filters -->
       <div class="filter-column">
         <o-text-input class="filter-element" attr="pck_name" read-only="no" fxFlex="100" label="Nombre" ></o-text-input>
         <o-integer-input  attr="pck_days" label="Number of Days" min="0"></o-integer-input>
       </div>
+      <!-- Price filter -->
       <div class="filter-column">
         <o-integer-input class="filter-element" attr="pck_price_min" label="Min Price" min="0"></o-integer-input>
         <o-integer-input  attr="pck_price_max" label="Max Price" min="0"></o-integer-input>
       </div>
+      <!-- Travellers and city filter -->
       <div class="filter-column">
         <o-integer-input class="filter-element" attr="pck_participants" min="0" label="Number of Travelers" ></o-integer-input>
         <o-combo  #comboCity attr="gui_c_name" label="Ciudad"  translate="yes"
           query-method="query" sort="ASC" value-column="gui_c_name" required="no" service="guideCities" multiple="no" null-selection="yes" entity="guideCities"
           columns="gui_c_name" visible-columns="gui_c_name" keys="gui_c_id"></o-combo>
       </div>
+      <!-- Filter buttons -->
       <div class="filter-column">
         <o-button attr="filter" [oFilterBuilderQuery]="filterBuilder" type="ICON" icon="search" matTooltip="Search" class="filter-button"></o-button>
         <o-button attr="clear" type="ICON" icon="delete" matTooltip="Clear filters" class="filter-button" [oFilterBuilderClear]="filterBuilder"  [oFilterBuilderQuery]="filterBuilder" ></o-button>
       </div>
     </div>
     
+    <!-- Filter builder -->
     <o-filter-builder #filterBuilder attr="thefilter"
       filters="pck_name:pck_name;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
       [target]="packGrid" query-on-change="no" query-on-change-delay="500" [expression-builder]="createFilter"></o-filter-builder>

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.html
@@ -1,49 +1,25 @@
-<!-- Boton para abrir dialogo -->
-<o-button attr="packFilter" type="FAB" icon="tune" layout-padding (click)="showFilter($event)"></o-button>
+<o-form class="form" editable-detail="yes" show-header="no">
+  <div class="filter">
+    <o-text-input attr="pck_name" read-only="no" fxFlex="100" label="Nombre" appearance="outline"></o-text-input>
+    <o-integer-input attr="pck_days" label="Number of Days" appearance="outline"></o-integer-input>
+    <o-real-input attr="pck_price_min" label="Min Price" appearance="outline"></o-real-input>
+    <o-real-input attr="pck_price_max" label="Max Price" appearance="outline"></o-real-input>
+    <o-integer-input attr="pck_participants" label="Number of Travelers" appearance="outline"></o-integer-input>
+    <o-combo #comboCity attr="gui_c_name" label="Ciudad"  translate="yes"
+      query-method="query" sort="ASC" value-column="gui_c_name" required="no" service="guideCities" multiple="no" null-selection="yes" entity="guideCities"
+      columns="gui_c_name" visible-columns="gui_c_name" keys="gui_c_id"></o-combo>
+  </div>
+  <o-filter-builder #filterBuilder attr="thefilter"
+    filters="pck_name:pck_name;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
+    [target]="packGrid" query-on-change="yes" query-on-change-delay="500" [expression-builder]="createFilter"></o-filter-builder>
+</o-form>
 
-<!-- Plantilla para el dialogo -->
-<ng-template #filterDialogTemplate>
-  <o-form editable-detail="no" show-header="no">
-    <div class="filter">
-      <!-- Filtro de palabras clave -->
-      <o-text-input attr="pck_name" read-only="no" placeholder="Nombre"></o-text-input>
-      
-      <!-- Filtro de rango de fechas -->
-      <o-date-input attr="pck_date_begin" read-only="no" label="Fecha inicio" format="DD/MM/YYYY HH:MM:SS"></o-date-input>
-      <o-date-input attr="pck_date_end" read-only="no" label="Fecha fin"></o-date-input>
-      
-      <!-- Filtro de número de días -->
-      <o-integer-input attr="pck_days" read-only="no" label="Número de días"></o-integer-input>
-      
-      <!-- Filtro de rango de precio -->
-      <o-real-input attr="pck_price_min" read-only="false" placeholder="Precio mínimo"></o-real-input>
-      <o-real-input attr="pck_price_max" read-only="false" placeholder="Precio máximo"></o-real-input>
-      
-      <!-- Filtro de número de viajeros -->
-      <o-integer-input attr="pck_participants" read-only="no" label="Número de viajeros"></o-integer-input>
-      
-      <!-- Filtro de lugar -->
-      <o-combo attr="gui_c_name" searchable="yes" read-only="no" service="places" entity="place" keys="PLACE_ID"
-        columns="PLACE_ID;PLACE_NAME" visible-columns="PLACE_NAME" value-column="PLACE_ID"></o-combo>
-    </div>
-
-    <o-filter-builder #filterBuilder attr="packFilter"
-      filters="pck_name:pck_name;pck_date_begin:pck_date_begin;pck_date_end:pck_date_end;pck_days:pck_days;pck_price_min:pck_price_min;pck_price_max:pck_price_max;pck_participants:pck_participants;gui_c_name:gui_c_name"
-      [target]="packGrid" query-on-change="yes" query-on-change-delay="500" [expression-builder]="filter">
-    </o-filter-builder>
-
-    <div class="dialog-buttons" fxLayout="row" fxLayoutAlign="end center">
-      <button mat-button (click)="applyFilter()">Filter</button>
-      <button mat-button (click)="closeDialog()">Close</button>
-    </div>
-  </o-form>
-</ng-template>
 <o-grid #packGrid attr="packGrid" title="PACKS" service="packs" entity="allPacks" keys="P.pck_id"
-    columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;pcs_id;img_code;pck_days;creation_date"
+    columns="P.pck_id;pck_name;pck_description;pck_price;pck_participants;gui_c_name;img_code;pck_days;creation_date"
     query-rows="8" page-size-options="8;16;24" orderable="true" sort-column="creation_date:desc"
-    sortable-columns="pck_name;pck_date_begin;pck_date_end;gui_c_name;pcs_id;creation_date;pck_name:desc;pck_date_begin:desc;pck_date_end:desc;gui_c_name:desc;pcs_id:desc;creation_date:desc" 
+    sortable-columns="" 
     quick-filter-columns="pck_name;pck_price;pck_participants;gui_c_name" filter-case-sensitive="yes"
-    insert-button="true" refresh-button="true" pageable="yes"
+    insert-button="true" refresh-button="false" pageable="yes"
     pagination-controls="true" gutter-size="4px" fixed-header="yes" grid-item-height="320px" detail-mode="none"
     insert-button-floatable="no">
     <o-grid-item *ngFor="let data of packGrid.dataArray">

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
@@ -67,70 +67,42 @@ export class PackHomeComponent {
     return tempFecha.toLocaleDateString();
   }
 
-  filter(values: Array<{ attr: string, value: any }>): Expression {
+  //FILTROS
+  createFilter(values: Array<{ attr: string, value: any }>): Expression {
     let filters: Array<Expression> = [];
+
     values.forEach(fil => {
-        if (fil.value) {
-            if (fil.attr === 'pck_name') {
-                let keyword = fil.value;
-                filters.push(FilterExpressionUtils.buildExpressionLike("pck_name", `%${keyword}%`));
-            }
-            if (fil.attr === 'pck_date_begin') {
-              let dateBegin = fil.value;
-              filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_date_begin", new Date(dateBegin).toISOString().slice(0, 10)));
-            }
-            if (fil.attr === 'pck_date_end') {
-                let dateEnd = fil.value;
-                filters.push(FilterExpressionUtils.buildExpressionLessEqual("pck_date_end", new Date(dateEnd).toISOString().slice(0, 10)));
-            }
-            if (fil.attr === 'pck_days') {
-              let days = Number(fil.value);
-              filters.push(FilterExpressionUtils.buildExpressionEquals(
-                  `DATE_PART('day', DATE_TRUNC('day', pck_date_end) - DATE_TRUNC('day', pck_date_begin))`,
-                  days
-              ));
-          }
-            if (fil.attr === 'pck_price_min') {
-                let value: number = Number(fil.value);
-                filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_price", value));
-            }
-            if (fil.attr === 'pck_price_max') {
-                let value: number = Number(fil.value);
-                filters.push(FilterExpressionUtils.buildExpressionLessEqual("pck_price", value));
-            }
-            if (fil.attr === 'pck_participants') {
-                filters.push(FilterExpressionUtils.buildExpressionEquals("pck_participants", fil.value));
-            }
-            if (fil.attr === 'gui_c_name') {
-                filters.push(FilterExpressionUtils.buildExpressionEquals("gui_c_name", fil.value));
-            }
+      if (fil.value) {
+        if (fil.attr === 'pck_name') {
+          let keyword = fil.value;
+          filters.push(FilterExpressionUtils.buildExpressionLike("pck_name", `%${keyword}%`));
         }
+        if (fil.attr === 'pck_days') {
+          filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_days", fil.value));
+        }
+        if (fil.attr === 'pck_price_min') {
+          let value: number = Number(fil.value);
+          filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_price", value));
+        }
+        if (fil.attr === 'pck_price_max') {
+          let value: number = Number(fil.value);
+          filters.push(FilterExpressionUtils.buildExpressionLessEqual("pck_price", value));
+        }
+        if (fil.attr === 'pck_participants') {
+          filters.push(FilterExpressionUtils.buildExpressionEquals("pck_participants", fil.value));
+        }
+        if (fil.attr === 'gui_c_name') {
+          filters.push(FilterExpressionUtils.buildExpressionEquals("gui_c_name", fil.value));
+        }
+      }
     });
 
     if (filters.length > 0) {
-        return filters.reduce((exp1, exp2) => 
-            FilterExpressionUtils.buildComplexExpression(exp1, exp2, FilterExpressionUtils.OP_AND)
-        );
+      return filters.reduce((exp1, exp2) => 
+        FilterExpressionUtils.buildComplexExpression(exp1, exp2, FilterExpressionUtils.OP_AND)
+      );
     } else {
-        return null;
+      return null;
     }
-  }
-
-  showFilter(evt: any) {
-    this.dialogRef = this.dialog.open(this.filterDialogTemplate, {
-      width: '50%',
-      height: '50%',
-    });
-  }
-
-  applyFilter() {
-    const filterBuilder = this.filterDialogTemplate['filterBuilder'];
-    const filters = filterBuilder.getExpression();
-    this.packGrid.queryData(filters);
-    this.dialogRef.close();
-  }
-
-  closeDialog() {
-    this.dialogRef.close();
   }
 }

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
@@ -2,7 +2,7 @@
 import { Component, Injector, ViewChild, TemplateRef } from "@angular/core";
 import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { DomSanitizer } from "@angular/platform-browser";
-import { Expression, FilterExpressionUtils, OGridComponent, OntimizeService } from "ontimize-web-ngx";
+import { Expression, FilterExpressionUtils, OFormComponent, OFormValue, OGridComponent, OntimizeService } from "ontimize-web-ngx";
 import { Router } from "@angular/router";
 
 @Component({
@@ -68,6 +68,7 @@ export class PackHomeComponent {
   }
 
   //FILTROS
+  @ViewChild("filterForm") protected filterForm: OFormComponent;
   createFilter(values: Array<{ attr: string, value: any }>): Expression {
     let filters: Array<Expression> = [];
 
@@ -78,7 +79,7 @@ export class PackHomeComponent {
           filters.push(FilterExpressionUtils.buildExpressionLike("pck_name", `%${keyword}%`));
         }
         if (fil.attr === 'pck_days') {
-          filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_days", fil.value));
+          filters.push(FilterExpressionUtils.buildExpressionEquals("pck_days", fil.value));
         }
         if (fil.attr === 'pck_price_min') {
           let value: number = Number(fil.value);
@@ -105,4 +106,10 @@ export class PackHomeComponent {
       return null;
     }
   }
+
+  clearFilter () {
+    const fieldsToClear = ['pck_name', 'pck_days', 'pck_price_min', 'pck_price_max', 'pck_participants', 'gui_c_name'];
+    this.filterForm.clearFieldValues(fieldsToClear);  
+  }
+
 }

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/pack/pack-home/pack-home.component.ts
@@ -1,11 +1,9 @@
 
-import { Component, ViewChild } from "@angular/core";
-import { MatDialog } from "@angular/material/dialog";
+import { Component, Injector, ViewChild, TemplateRef } from "@angular/core";
+import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { DomSanitizer } from "@angular/platform-browser";
-import { OGridComponent, OntimizeService } from "ontimize-web-ngx";
+import { Expression, FilterExpressionUtils, OGridComponent, OntimizeService } from "ontimize-web-ngx";
 import { Router } from "@angular/router";
-import moment from "moment";
-
 
 @Component({
   selector: "app-pack-home",
@@ -13,28 +11,34 @@ import moment from "moment";
   styleUrls: ["./pack-home.component.css"],
 })
 export class PackHomeComponent {
+
+  @ViewChild('filterDialogTemplate', { static: true }) filterDialogTemplate: TemplateRef<any>;
+  @ViewChild('packGrid', { static: true }) packGrid: OGridComponent;
+
   public showWaitForLongTask = false;
-
+  service: OntimizeService;
   public static page = 0;
+  private dialogRef: MatDialogRef<any>;
 
-    constructor(
+  constructor(
+    protected injector: Injector,
     private ontimizeService: OntimizeService,
     protected dialog: MatDialog,
     protected sanitizer: DomSanitizer,
-    private router: Router
+    private router: Router,
   ) {
     this.ontimizeService.configureService(
       this.ontimizeService.getDefaultServiceConfiguration("packs")
     );
+    this.service = this.injector.get(OntimizeService);
   }
+
   ngOnInit() {}
 
   public openDetail(data: any): void {
     PackHomeComponent.page = 1;
     this.router.navigate(['main/packs/' + data.pck_id]);
   }
-
-
 
   public getImageSrc(base64: any): any {
     return base64
@@ -44,21 +48,12 @@ export class PackHomeComponent {
       : "./assets/images/no-image-transparent.png";
   }
 
-
   truncateName(name: string): string {
-    if (name.length > 22) {
-      return name.substr(0, 22) + "...";
-    } else {
-      return name;
-    }
+    return name.length > 25 ? name.substr(0, 25) + "..." : name;
   }
 
   truncateInfo(name: string): string {
-    if (name.length > 10) {
-      return name.substr(0, 10) + "...";
-    } else {
-      return name;
-    }
+    return name.length > 10 ? name.substr(0, 10) + "..." : name;
   }
 
   diferenciaDias(fechaInicio: number, fechaFin: number): number {
@@ -70,5 +65,72 @@ export class PackHomeComponent {
   getDate(fechaNumber: number): string {
     const tempFecha = new Date(fechaNumber);
     return tempFecha.toLocaleDateString();
+  }
+
+  filter(values: Array<{ attr: string, value: any }>): Expression {
+    let filters: Array<Expression> = [];
+    values.forEach(fil => {
+        if (fil.value) {
+            if (fil.attr === 'pck_name') {
+                let keyword = fil.value;
+                filters.push(FilterExpressionUtils.buildExpressionLike("pck_name", `%${keyword}%`));
+            }
+            if (fil.attr === 'pck_date_begin') {
+              let dateBegin = fil.value;
+              filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_date_begin", new Date(dateBegin).toISOString().slice(0, 10)));
+            }
+            if (fil.attr === 'pck_date_end') {
+                let dateEnd = fil.value;
+                filters.push(FilterExpressionUtils.buildExpressionLessEqual("pck_date_end", new Date(dateEnd).toISOString().slice(0, 10)));
+            }
+            if (fil.attr === 'pck_days') {
+              let days = Number(fil.value);
+              filters.push(FilterExpressionUtils.buildExpressionEquals(
+                  `DATE_PART('day', DATE_TRUNC('day', pck_date_end) - DATE_TRUNC('day', pck_date_begin))`,
+                  days
+              ));
+          }
+            if (fil.attr === 'pck_price_min') {
+                let value: number = Number(fil.value);
+                filters.push(FilterExpressionUtils.buildExpressionMoreEqual("pck_price", value));
+            }
+            if (fil.attr === 'pck_price_max') {
+                let value: number = Number(fil.value);
+                filters.push(FilterExpressionUtils.buildExpressionLessEqual("pck_price", value));
+            }
+            if (fil.attr === 'pck_participants') {
+                filters.push(FilterExpressionUtils.buildExpressionEquals("pck_participants", fil.value));
+            }
+            if (fil.attr === 'gui_c_name') {
+                filters.push(FilterExpressionUtils.buildExpressionEquals("gui_c_name", fil.value));
+            }
+        }
+    });
+
+    if (filters.length > 0) {
+        return filters.reduce((exp1, exp2) => 
+            FilterExpressionUtils.buildComplexExpression(exp1, exp2, FilterExpressionUtils.OP_AND)
+        );
+    } else {
+        return null;
+    }
+  }
+
+  showFilter(evt: any) {
+    this.dialogRef = this.dialog.open(this.filterDialogTemplate, {
+      width: '50%',
+      height: '50%',
+    });
+  }
+
+  applyFilter() {
+    const filterBuilder = this.filterDialogTemplate['filterBuilder'];
+    const filters = filterBuilder.getExpression();
+    this.packGrid.queryData(filters);
+    this.dialogRef.close();
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
   }
 }

--- a/cd2024bfs2g1-model/src/main/resources/dao/pack/PackDao.xml
+++ b/cd2024bfs2g1-model/src/main/resources/dao/pack/PackDao.xml
@@ -46,18 +46,15 @@
                     SELECT DISTINCT
                         #COLUMNS#
                     FROM
-                        ${mainschema}.pack P
-                        INNER JOIN ${mainschema}.image_pack IP
-                        ON P.pck_id=IP.pck_id
-                        INNER JOIN ${mainschema}.image I
-                        ON IP.img_id=I.image_id
-                        INNER JOIN ${mainschema}.gui_cities GC
-                        ON P.gui_c_id=GC.gui_c_id
-                        INNER JOIN ${mainschema}.pack_date PD
-                        ON P.pck_id=PD.pck_id
-                    WHERE
-                        PD.pcs_id = 1
-                    #WHERE#
+                       pack P
+                        INNER JOIN image_pack IP
+                        ON P.pck_id = IP.pck_id
+                        INNER JOIN image I
+                        ON IP.img_id = I.image_id
+                        INNER JOIN gui_cities GC
+                        ON P.gui_c_id = GC.gui_c_id
+                       WHERE P.pck_id in (select distinct spd.pck_id from pack_date spd where spd.pcs_id = 1)
+                    #WHERE_CONCAT#
                     #ORDER#
                 ]]>
             </Sentence>

--- a/cd2024bfs2g1-model/src/main/resources/dao/pack/PackDao.xml
+++ b/cd2024bfs2g1-model/src/main/resources/dao/pack/PackDao.xml
@@ -47,12 +47,12 @@
                         #COLUMNS#
                     FROM
                        pack P
-                        INNER JOIN image_pack IP
-                        ON P.pck_id = IP.pck_id
-                        INNER JOIN image I
-                        ON IP.img_id = I.image_id
-                        INNER JOIN gui_cities GC
-                        ON P.gui_c_id = GC.gui_c_id
+                           INNER JOIN image_pack IP
+                           ON P.pck_id = IP.pck_id
+                           INNER JOIN image I
+                           ON IP.img_id = I.image_id
+                           INNER JOIN gui_cities GC
+                           ON P.gui_c_id = GC.gui_c_id
                        WHERE P.pck_id in (select distinct spd.pck_id from pack_date spd where spd.pcs_id = 1)
                     #WHERE_CONCAT#
                     #ORDER#


### PR DESCRIPTION
GAL-23
‎ ‏‏‎1. Los filtros disponibles serán:
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎a. Palabras clave (nombre)
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎b. Rango de fechas (falta implementar)
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎c. Número de días
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎d. Rango de precio
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎e. Número de viajeros
‎ ‏‏‎‎ ‏‏‎‎ ‏‏‎f. Lugar
‎ ‏‏‎2. Estará disponible un check para ver solo los packs activos (por defecto estará activo). En caso de estar desmarcado se visualizarán también los reservados.
 2.1 Ahora solo se muestran los activos y ya no es necesario (ver punto 4).
‎ ‏‏‎3. Los resultados se obtendrán paginados.
‎ ‏‏‎4. El cliente solo podrá ver los packs que tengan fechas.