### PR TITLE
Mejoras visuales routes y botón de my-packs

### DIFF
--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/my-packs/pack-client-detail/pack-client-detail.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/my-packs/pack-client-detail/pack-client-detail.component.css
@@ -164,7 +164,7 @@
 }
 
 .cancel-pack{
-    height: 70px;
+    height: 35px;
     width: 200px;
     background-color: rgba(235, 13, 13, 0.778);
     border-radius: 20px; 
@@ -182,7 +182,7 @@
 }
 
 .cancel-pack-disabled {
-    height: 70px;
+    height: 35px;
     width: 200px;
     background-color: gray;
     border-radius: 20px; 
@@ -205,7 +205,7 @@
   border-radius: 6px;
   position: absolute;
   transform: translateX(-70%) translateY(-10px);
-  bottom: 14%;
+  bottom: 11%;
   opacity: 0;
   transition: opacity 0.3s;
   white-space: nowrap;

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-detail/routes-detail.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-detail/routes-detail.component.css
@@ -69,6 +69,11 @@
   background-color: transparent;
 }
 
+.descriptionText {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 .titulo {
   font-size: 24px;
   font-weight: bold;
@@ -84,8 +89,6 @@
   overflow: hidden;
 
 }
-
-
 
 .estimatedDuration {
   display: flex;
@@ -198,7 +201,7 @@
 
 .backButton {
   position: absolute;
-  left: 20px;
+  left: 35px;
 }
 
 .o-rows {
@@ -213,7 +216,7 @@
   border-color: #84A45A;
   color: #000000;
   text-align: center;
-  font-size: 15px;
+  font-size: 12.5px;
   border-radius: 6px;
   position: absolute;
   z-index: 1;
@@ -254,7 +257,7 @@
   border-color: #84A45A;
   color: #000000;
   text-align: center;
-  font-size: 15px;
+  font-size: 12.5px;
   border-radius: 6px;
   position: absolute;
   z-index: 1;

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-detail/routes-detail.component.html
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-detail/routes-detail.component.html
@@ -15,7 +15,7 @@
             <o-row class="o-rows" class="description" attr="container" icon="description" mat
                         title="{{'DESCRIPTION' | oTranslate }}" layout-align="start stretch" elevation="1"
                         aria-orientation="vertical" appearance="outline">
-                <span *ngIf="data.description; else no_description">
+                <span class="descriptionText" *ngIf="data.description; else no_description">
                     <mat-icon></mat-icon><span>{{ data.description }}</span>
                 </span>
                 <ng-template #no_description>

--- a/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-home/routes-home.component.css
+++ b/cd2024bfs2g1-frontend/src/main/ngx/src/app/main/routes/routes-home/routes-home.component.css
@@ -68,7 +68,7 @@
   cursor: pointer;
 }
 
-.tooltipHomeDifficulty .tooltiptextHomeDifficulty {
+.tooltiptextHomeDifficulty {
   visibility: hidden;
   width: auto;
   background-color: white;
@@ -108,7 +108,7 @@
   border-color: #84A45A;
   color: #000000;
   text-align: center;
-  font-size: 15px;
+  font-size: 12.5px;
   border-radius: 6px;
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
- Ajustado el botón de cancelar packs, más pequeño.
- Reducido el texto de los tooltips de routes details y routes home.
- Espaciado en routes details en la zona de la descripción contra el texto.
- Ajustada la flecha de routes details.